### PR TITLE
Update go version to 1.13.7 and add a build stage to the Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-- "1.10"
+- "1.13.7"
 
 script:
   - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 language: go
+go_import_path: github.com/kubernetes-incubator/metrics-server
 
 go:
 - "1.13.7"

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/kubernetes-incubator/metrics-server
 RUN cd /go/src/github.com/kubernetes-incubator/metrics-server && \
     make _output/amd64/metrics-server
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static@sha256:08322afd57db6c2fd7a4264bf0edd9913176835585493144ee9ffe0c8b576a76
 
 COPY --from=builder /go/src/github.com/kubernetes-incubator/metrics-server/_output/amd64/metrics-server /
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,10 @@
-FROM BASEIMAGE
+FROM golang:1.13.7 as builder
+COPY . /go/src/github.com/kubernetes-incubator/metrics-server
+RUN cd /go/src/github.com/kubernetes-incubator/metrics-server && \
+    make _output/amd64/metrics-server
 
-COPY metrics-server /
+FROM gcr.io/distroless/static:latest
+
+COPY --from=builder /go/src/github.com/kubernetes-incubator/metrics-server/_output/amd64/metrics-server /
 
 ENTRYPOINT ["/metrics-server"]


### PR DESCRIPTION
* Add a golang:1.13.7 build stage to the Dockerfile
* Update go version in .travis.yml

I think the image build options would be:

Branch: release/v0.3.6
Docker tag: metrics-server-amd64:v0.3.6
Dockerfile location: deploy/docker/Dockerfile
Build context: /
